### PR TITLE
[PERFORMANCE] Remove children dependance on ScrollToTop

### DIFF
--- a/client/src/components/Routes.jsx
+++ b/client/src/components/Routes.jsx
@@ -11,8 +11,8 @@ import Footer from "./Footer";
 const Routes = () => {
     return (
         <>
+            <ScrollToTop/>
             <Switch>
-                <ScrollToTop>
                     <Route exact path="/">
                         <Home />
                     </Route>
@@ -38,7 +38,6 @@ const Routes = () => {
                         <div style={{ height: "300vh" }}>
                         </div>
                     </Route>
-                </ScrollToTop>
 
 
             </Switch>

--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
-import { useLocation, withRouter } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useSpring } from 'react-spring';
 
-const ScrollToTop = ({ children }) => {
+const ScrollToTop = () => {
   const prevLocation = useRef();
   const location = useLocation();
   const [, setY] = useSpring(() => ({ y: 0 }))
@@ -17,9 +17,9 @@ const ScrollToTop = ({ children }) => {
       });
       prevLocation.current = location.pathname;
     }
-  }, [location]);
+  }, [location, setY]);
 
-  return children;
+  return null;
 };
 
 


### PR DESCRIPTION
Closes #24 

Since ALL PAGES were children of the ScrollToTop component, the whole page got re-rendered sometimes when the scroll to top was triggered. Removing this improved a lot the app's flow. 

Please test accordingly and let me know if you find any performance issues